### PR TITLE
Perform a quick precheck before the regex search

### DIFF
--- a/filter.php
+++ b/filter.php
@@ -68,7 +68,7 @@ class filter_multilang2 extends moodle_text_filter {
     public function filter($text, array $options = array()) {
         global $CFG;
 
-        if (empty($text) or is_numeric($text)) {
+        if (stripos($text, 'mlang') === false) {
             return $text;
         }
 


### PR DESCRIPTION
It is a common good pattern in Moodle filters to firstly perform a quick
and cheap check for a keyword presence in the text before attempting to
do the full regex based search and replace. This significantly improves
the performance, especially where the filter syntax is quite rare in the
texts.

Such a check in this case effectively replaces the empty() and
is_numeric() prechecks.