### PR TITLE
 Allowing PHP Unit to work in version 8 and above

### DIFF
--- a/tests/filter_test.php
+++ b/tests/filter_test.php
@@ -53,7 +53,7 @@ class filter_multilang2_testcase extends advanced_testcase {
      *
      * @return void
      */
-    protected function setUp() {
+    protected function setUp():void {
         parent::setUp();
         $this->resetAfterTest(true);
         $this->filter = new filter_multilang2(context_system::instance(), array());


### PR DESCRIPTION
Changes in PHP Unit library version 8:

https://phpunit.de/announcements/phpunit-8.html

This will still work in earlier versions of PHP Unit 