### PR TITLE
Add text sanitisation workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 # To Enable it #
 - Go to "Site Administration &gt;&gt; Plugins &gt;&gt; Filters &gt;&gt; Manage filters" and enable the plugin there.
+- Move the "Multi-Language Content (v2)" filter to the top of list of filters so that it is executed before any other
+filter that may be adding any interactive content that is not compatible with standard Moodle text cleaning.
 
 # To Use it #
 - Create your contents in multiple languages.
@@ -25,6 +27,7 @@
   - Else, as fallback, print the text with language 'other' if such
    one is set.
 - Text outside of "lang blocks" will always be shown.
+- All untrusted text is automatically sanitised after multilang processing.
 
 ## Definition of "lang block" ##
 Is any text (including spaces, tabs, linefeeds or return characters) placed between '{mlang XX}' and '{mlang}' markers. You can not only put text inside "lang block", but also images, videos or external embedded content. For example, this is a valid "lang block":

--- a/filter.php
+++ b/filter.php
@@ -114,6 +114,9 @@ class filter_multilang2 extends moodle_text_filter {
             return $text; // Error during regex processing, keep original text.
         }
         if ($this->replacementdone) {
+            if (empty($options['noclean'])) {
+                $result = purify_html($result, ['allowid' => true]);
+            }
             return $result;
         }
 
@@ -125,6 +128,9 @@ class filter_multilang2 extends moodle_text_filter {
                                         $text);
         if (is_null($result)) {
             return $text;
+        }
+        if (empty($options['noclean'])) {
+            $result = purify_html($result, ['allowid' => true]);
         }
         return $result;
     }

--- a/tests/filter_test.php
+++ b/tests/filter_test.php
@@ -26,6 +26,10 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace filter_multilang2;
+
+use filter_multilang2, context_system, advanced_testcase;
+
 defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
@@ -43,7 +47,7 @@ require_once($CFG->dirroot . '/filter/multilang2/filter.php');
  * @copyright  2016 Iñaki Arenaza & Mondragon Unibertsitatea
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class filter_multilang2_testcase extends advanced_testcase {
+class filter_test extends advanced_testcase {
 
     /** @var object The filter plugin object to perform the tests on */
     protected $filter;
@@ -292,6 +296,28 @@ class filter_multilang2_testcase extends advanced_testcase {
                 'before' => '{mlang ,es}Bad filter syntax{mlang}',
                 'after'  => '{mlang ,es}Bad filter syntax{mlang}',
             ),
+            array (
+                'filterwithlang' => 'en',
+                'before' => '<div class="stuff {mlang en}">Some{mlang}{mlang other}bad{mlang}</div>nesting',
+                'after'  => '<div class="stuff">Some</div>nesting',
+            ),
+            array (
+                'filterwithlang' => 'en',
+                'before' => '<div class="stuff {mlang es}">Some{mlang}{mlang other}bad{mlang}</div>nesting',
+                'after'  => '<div class="stuff bad&lt;/div&gt;nesting&lt;/div&gt;&lt;/body&gt;&lt;/html&gt;"></div>',
+            ),
+            array (
+                'filterwithlang' => 'en',
+                'before' => '<div class="stuff {mlang en}">Some{mlang}{mlang other}bad{mlang}</div>nesting',
+                'after'  => '<div class="stuff ">Some</div>nesting',
+                'options' => ['noclean' => true],
+            ),
+            array (
+                'filterwithlang' => 'en',
+                'before' => '<div class="stuff {mlang es}">Some{mlang}{mlang other}bad{mlang}</div>nesting',
+                'after'  => '<div class="stuff bad</div>nesting',
+                'options' => ['noclean' => true],
+            ),
         );
 
         // As we need to switch languages to test the filter, store the current
@@ -299,7 +325,12 @@ class filter_multilang2_testcase extends advanced_testcase {
         $currlang = $CFG->lang;
         foreach ($tests as $test) {
             $CFG->lang = $test['filterwithlang'];
-            $this->assertEquals($test['after'], $this->filter->filter($test['before']));
+            if (isset($test['options'])) {
+                $options = $test['options'];
+            } else {
+                $options = [];
+            }
+            $this->assertEquals($test['after'], $this->filter->filter($test['before'], $options));
         }
         $CFG->lang = $currlang;
     }


### PR DESCRIPTION
Here is a patch for security issue that I have found. Feel free to contact me via email from the git commit message if you want me to explain the details of exploit.

Please note this is more like a workaround, the proper fix would be to execute the filtering before text cleanup in format_text() function, but I doubt Moodle HQ is going to do anything about it.